### PR TITLE
Fixed intermittent errors at fetch time

### DIFF
--- a/src/lib/algorand.ts
+++ b/src/lib/algorand.ts
@@ -108,19 +108,15 @@ export async function getListings(tagName: string, minPrice=0, maxPrice=0): Prom
 
     const balances =  await lookup.do()
 
-    const lp = []
     const listings = []
     for (let bidx in balances.balances) {
         const b = balances.balances[bidx]
 
         if (b.address == ps.application.owner_addr || b.amount == 0) continue;
 
-        lp.push(getListing(b.address).then((listing)=>{
-             listings.push(listing)
-        }))
+        const listing = await getListing(b.address);
+        listings.push(listing);
     }
-
-    await Promise.all(lp)
 
     return listings
 }


### PR DESCRIPTION
We've detected intermittent errors through our tests, when consuming the testnet.

Seems that somehow the indexer gets overflown by too many parallel requests, and throws `503` errors at random.
To solve this, an await was added inside the loop.